### PR TITLE
remove duplicated http:// from hugo link

### DIFF
--- a/layouts/partials/sidebar-content.html
+++ b/layouts/partials/sidebar-content.html
@@ -26,6 +26,6 @@
 		</div>
 
 		<p class="copyright">{{ with .Site.Params.copyright }}{{ . }}{{ else }}&copy; {{ now.Format "2006" }}. All rights reserved. {{end}}</p>
-		<p class="attr">Powered by <a href="http://http://gohugo.io">Hugo</a> &amp; <a href="https://github.com/ExchangeRate-API/strange-case">Strange Case</a> (inspired by <a href="https://github.com/poole/hyde">Hyde</a>).</p>
+		<p class="attr">Powered by <a href="http://gohugo.io">Hugo</a> &amp; <a href="https://github.com/ExchangeRate-API/strange-case">Strange Case</a> (inspired by <a href="https://github.com/poole/hyde">Hyde</a>).</p>
 
 	</div>


### PR DESCRIPTION
Hi there

First of all, thanks for this great theme. I'm switching to this theme today and stumbled the link to Hugo website on the left side bar was in correct. Probably, just a typo of duplicated 'http://'.

Hope you accept this little pull request.

Cheers
Kenno