### PR TITLE
Added support for pagination

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
 			</div>
 			<div class="col-sm-7 col-sm-offset-4 col-md-6 col-md-offset-3 col-lg-5 col-lg-offset-3 content">
 
-				{{ range first 10 .Data.Pages }}
+				{{ range .Paginator.Pages }}
 				<div class="post">
 
 					<div class="post-heading">
@@ -21,6 +21,10 @@
 
 				</div>
 				{{ end }}
+
+				<div class="text-center">
+					{{ template "_internal/pagination.html" . }}
+				</div>
 
 			</div>
 			<div class="col-sm-1 col-md-3 col-md-4">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
 			</div>
 			<div class="col-sm-7 col-sm-offset-4 col-md-6 col-md-offset-3 col-lg-5 col-lg-offset-3 content">
 
-				{{ range first 10 .Data.Pages }}
+				{{ range .Paginator.Pages }}
 				<div class="post">
 
 					<div class="post-heading">
@@ -21,6 +21,10 @@
 
 				</div>
 				{{ end }}
+
+				<div class="text-center">
+					{{ template "_internal/pagination.html" . }}
+				</div>
 
 			</div>
 			<div class="col-sm-1 col-md-3 col-md-4">


### PR DESCRIPTION
Hello!

First of all, thanks for the great theme. I use it for my personal blog.

I noticed that in the sample config, there was a mention of the ``paginate`` parameter but the default layout didn't use the paginator.

**Changes:**
- Added pagination
- Built-in Hugo pagination template is used as the pagination control.

It looks something like this with the base color scheme:
![image](https://user-images.githubusercontent.com/1111880/33523618-74ac62d8-d846-11e7-9022-53d5446e8ebe.png)

I'm not sure if I should add in the css to change the pagination text color to blue - my design sense isn't the best but that black-on-blue looks a tad weird. Let me know what you think?

If this isn't what you're looking for in the pull request, that's ok too. Thanks.