### PR TITLE
Add link in header to the RSS file generated by Hugo.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,5 +22,8 @@
 	<script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 	{{ "<![endif]-->" | safeHTML }}
+
+	<!-- RSS -->
+	<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 </head>
 <body class="{{ .Site.Params.colorScheme }}">


### PR DESCRIPTION
Currently, Strange does not add a link to the RSS file in the site's header, where other themes do. This makes it impossible for RSS readers (both browser plugins and online services, e.g. Feedly) to find the RSS file and process it.

This PR adds this link.